### PR TITLE
Make datadog integration safer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ idna==2.5
 requests==2.18.3
 simplejson==3.11.1
 urllib3==1.22
+boto3==1.9.221
+botocore==1.12.221


### PR DESCRIPTION
- Get Datadog secret from secrets manager directly
- Add another variable that would allow us to just enable / disable datadog integration