### PR TITLE
INFRA-1283 Ignore decode errors from clamav output

### DIFF
--- a/clamav.py
+++ b/clamav.py
@@ -204,7 +204,7 @@ def scan_file(path):
         stdout=subprocess.PIPE,
         env=av_env,
     )
-    output = av_proc.communicate()[0].decode()
+    output = av_proc.communicate()[0].decode(errors="ignore")
     print("clamscan output:\n%s" % output)
 
     # Turn the output into a data source we can read


### PR DESCRIPTION
Sometimes there is some non utf-8 output from the AV scanner, e.g.

```
Scanning /test!ZIP:_rels/.rels!ZIP:xl/_rels/workbook.xml.rels!ZIP:xl/workbook.xml\nScanning /test!ZIP:_rels/.rels!ZIP:xl/_rels/workbook.xml.rels!ZIP:xl/workbook.xml!ZIP:\xc4\xa3\xe4\xc1\x05\xb6\xb021)\xf5\xd1\x80E\xacL\x87!}8`\x17+\xd3\x81H\x1f\x0eY\x87\xe5\x08\xc2G\x0bmde:e\xe9\xe3\x81\xaclm:k\xe9\xc1\x05\xc9\xd9rg*[6`H*S\xa7\xcb\xcf(s\x8c\x85\x8e\x16\x11\xbcx\xb9\xd8\x9a\x8a2-\x98VV\x16<K9\xa3\xc5\x83\x8fL\n\x98e\x8f}\x82iU\xff\xad\xa9d\xd3\xe2\xc1\xb7"E8K\x80\xd1\x82\xf5\x12\x17\r\xd9\xb2\xc7a\xe4\xb0\xc2\xbde\x0b\xfe/k\xdb\x8b9{#\x9f\xabj\xcfX\x1a\x07\x0c\x07K\xdc\x8b9[\xc3uE\xf2Sr\x8a\xf38\xbe\x16\xbf\x857\xb3p\x8fY}:\xea\xd7\x9b$kE\xfe%o\xa1}~\xe1\xcc}\xc5Zh\xfd\x95\xe7GN\xc9/)c\x97\xaf\x18\xca5\x97\xf2y_\xe1#\xc4\xcc\xf24\x8fwY\xf0\xff\xca\xe2\xb8\x1c\x88&2i]\x02\xf6\x15GG\xd7\xda\xca<\xe2Kz\xf2.jY(\xc6\xbca\xec\x0e\xdd\xc0uz{\x99\n
```

We don't really care about this, as it's just from clamscan outputting what it's scanning - i.e. it doesn't affect the result of the scan. As such we can just ignore the errors.